### PR TITLE
fix(LINGUIST-569): Update profile prompt to only take user messages

### DIFF
--- a/chat/views/generate_chat_response.py
+++ b/chat/views/generate_chat_response.py
@@ -204,8 +204,12 @@ def generate_chat_response(request, conversation_id: str):
     
     # Update profile if needed
     if message_count > MAX_NO_OF_MESSAGE_CONTEXT:
+        
+        last_user_messages = Message.objects.filter(conversation=conversation, senderType="user").order_by('createdDate')[:MAX_NO_OF_MESSAGE_CONTEXT]
+        last_user_messages_str = [str(message) for message in last_user_messages]
+        last_user_messages_str = "\n".join(last_user_messages_str)
         logger.info("Profile _executor for conversation {} executing".format(conversation_id))
-        future_profile = _executor.submit(update_profile_async, profile, previous_messages_str, data)
+        future_profile = _executor.submit(update_profile_async, profile, last_user_messages_str, data)
         future_profile.add_done_callback(handle_profile_future_exception)
         logger.info("Profile _executor for conversation {} executed".format(conversation_id))
     

--- a/chat/views/generate_chat_response.py
+++ b/chat/views/generate_chat_response.py
@@ -203,8 +203,7 @@ def generate_chat_response(request, conversation_id: str):
     bot_message.save()
     
     # Update profile if needed
-    if message_count > MAX_NO_OF_MESSAGE_CONTEXT:
-        
+    if message_count % MAX_NO_OF_MESSAGE_CONTEXT == 0:
         last_user_messages = Message.objects.filter(conversation=conversation, senderType="user").order_by('createdDate')[:MAX_NO_OF_MESSAGE_CONTEXT]
         last_user_messages_str = [str(message) for message in last_user_messages]
         last_user_messages_str = "\n".join(last_user_messages_str)


### PR DESCRIPTION
For some reason (not due to my stupidity ofc), it was also taking bot's messages as well.

Also, for some reason (insert same joke here), it was also not updating in periods, but every time after a threshold.